### PR TITLE
Change timestamp format

### DIFF
--- a/src/main/java/com/morkaz/morkazsk/expressions/universal/ExprDateFromUnix.java
+++ b/src/main/java/com/morkaz/morkazsk/expressions/universal/ExprDateFromUnix.java
@@ -54,7 +54,7 @@ public class ExprDateFromUnix extends SimpleExpression<Date> {
 	}
 
 	protected Date[] get(Event event) {
-		Long longNumber = ((Number)this.numberExpr.getSingle(event)).longValue();
+		Long longNumber = ((Number)this.numberExpr.getSingle(event)).longValue() * 1000;
 		return new Date[]{new Date(longNumber)};
 	}
 


### PR DESCRIPTION
Java expects milliseconds, so multiply the input number by 1000, creating a valid date object from a unix timestamp.